### PR TITLE
ssh: Decouple `password` and `passphrase`.

### DIFF
--- a/dvc_ssh/tests/test_prepare_credentials.py
+++ b/dvc_ssh/tests/test_prepare_credentials.py
@@ -1,0 +1,15 @@
+import pytest
+
+from dvc_ssh import SSHFileSystem
+
+
+@pytest.mark.parametrize("password", [None, "foo"])
+@pytest.mark.parametrize("passphrase", [None, "bar"])
+def test_passphrase(mocker, password, passphrase):
+    connect = mocker.patch("asyncssh.connect")
+
+    kwargs = {"password": password, "passphrase": passphrase}
+    _ = SSHFileSystem(host="foo", **kwargs).fs
+
+    assert connect.call_args[1]["password"] == password
+    assert connect.call_args[1]["passphrase"] == passphrase


### PR DESCRIPTION
Add `password_as_passphrase` flag to indicate whether the old behavior should be preserved or not. Defaults to `True` to keep old behavior by default.

Introduce new options `passphrase` and `ask_passphrase`.

Depends on updating config_schema on `dvc` repo.