### PR TITLE
ssh: catch EOFError from getpass

### DIFF
--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -13,9 +13,13 @@ DEFAULT_PORT = 22
 @wrap_with(threading.Lock())
 @memoize
 def ask_password(host, user, port, desc):
-    return getpass.getpass(
-        f"Enter a {desc} for " f"host '{host}' port '{port}' user '{user}':\n"
-    )
+    try:
+        return getpass.getpass(
+            f"Enter a {desc} for "
+            f"host '{host}' port '{port}' user '{user}':\n"
+        )
+    except EOFError:
+        return None
 
 
 # pylint:disable=abstract-method


### PR DESCRIPTION
If getpass is unable to get input from stderror or stdin, it will raise this error.

Similar to how we do it in dvc https://github.com/iterative/dvc/blob/04e891cef929567794ade4e0c2a1bf399666f66e/dvc/ui/__init__.py#L268