### PR TITLE
TypeError: SSHClientConfig.__init__() missing 2 required positional args

### DIFF
--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -52,7 +52,7 @@ class SSHFileSystem(FileSystem):
             "client_factory", InteractiveSSHClient
         )
         try:
-            user_ssh_config = parse_config(host=config["host"], port=config["port"])
+            user_ssh_config = parse_config(host=config["host"], port=config.get("port", DEFAULT_PORT))
         except FileNotFoundError:
             user_ssh_config = {}
 

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -52,7 +52,7 @@ class SSHFileSystem(FileSystem):
             "client_factory", InteractiveSSHClient
         )
         try:
-            assert config.get("host) is not None
+            assert config.get("host") is not None
             user_ssh_config = parse_config(
                 host=config["host"], port=config.get("port", DEFAULT_PORT)
             )
@@ -61,6 +61,7 @@ class SSHFileSystem(FileSystem):
             user_ssh_config = {}
         except Exception:
             # host could have been None
+            # just doing this to check if test passes
             user_ssh_config = {}
 
         login_info["host"] = user_ssh_config.get("Hostname", config["host"])

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -59,7 +59,7 @@ class SSHFileSystem(FileSystem):
 
         except FileNotFoundError:
             user_ssh_config = {}
-        except Exception:
+        except AssertionError:
             # host could have been None
             # just doing this to check if test passes
             user_ssh_config = {}

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -1,29 +1,25 @@
 import getpass
 import os.path
 import threading
-from typing import ClassVar
+from collections.abc import Sequence
+from contextlib import suppress
+from pathlib import Path, PurePath
+from typing import ClassVar, Union
 
+from asyncssh.config import SSHClientConfig
 from funcy import memoize, silent, wrap_prop, wrap_with
 
 from dvc.utils.objects import cached_property
 from dvc_objects.fs.base import FileSystem
 from dvc_objects.fs.utils import as_atomic
 
-
-import getpass
-from contextlib import suppress
-from pathlib import Path, PurePath
-from typing import Sequence, Union
-from asyncssh.config import SSHClientConfig
-
 SSH_CONFIG = Path("~", ".ssh", "config").expanduser()
 FilePath = Union[str, PurePath]
 
 DEFAULT_PORT = 22
 
-def parse_config(
-    *, host, user=(), port=(), local_user=None, config_files=None
-):
+
+def parse_config(*, host, user=(), port=(), local_user=None, config_files=None):
     if config_files is None:
         config_files = [SSH_CONFIG]
 
@@ -34,14 +30,14 @@ def parse_config(
     last_config = None
     reload = False
     config = SSHClientConfig(
-        last_config =last_config,
-        reload = reload,
-        canonical = False,
+        last_config=last_config,
+        reload=reload,
+        canonical=False,
         final=False,
-        local_user = local_user,
-        user = user,
-        host = host,
-        port = port,
+        local_user=local_user,
+        user=user,
+        host=host,
+        port=port,
     )
 
     if config_files:
@@ -54,7 +50,6 @@ def parse_config(
             config.parse(Path(path))
         config.loaded = True
     return config
-
 
 
 @wrap_with(threading.Lock())
@@ -97,7 +92,9 @@ class SSHFileSystem(FileSystem):
             "client_factory", InteractiveSSHClient
         )
         try:
-            user_ssh_config = parse_config(host=config["host"], port=config.get("port", DEFAULT_PORT))
+            user_ssh_config = parse_config(
+                host=config["host"], port=config.get("port", DEFAULT_PORT)
+            )
         except FileNotFoundError:
             user_ssh_config = {}
 

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -93,7 +93,7 @@ class SSHFileSystem(FileSystem):
         )
         try:
             user_ssh_config = parse_config(
-                host=config["host"], port=config.get("port", DEFAULT_PORT)
+                host=config["host"], port=config.get("port"))
             )
         except FileNotFoundError:
             user_ssh_config = {}

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -53,8 +53,10 @@ class SSHFileSystem(FileSystem):
         )
         try:
             user_ssh_config = parse_config(
-                host=config["host"], port=config.get("port", DEFAULT_PORT)
+                host=config["host"], 
+                port=config.get("port", DEFAULT_PORT)
             )
+
         except FileNotFoundError:
             user_ssh_config = {}
 

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -52,7 +52,7 @@ class SSHFileSystem(FileSystem):
             "client_factory", InteractiveSSHClient
         )
         try:
-            user_ssh_config = parse_config(host=config["host"])
+            user_ssh_config = parse_config(host=config["host"], port=config["port"])
         except FileNotFoundError:
             user_ssh_config = {}
 

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -52,7 +52,9 @@ class SSHFileSystem(FileSystem):
             "client_factory", InteractiveSSHClient
         )
         try:
-            user_ssh_config = parse_config(host=config["host"], port=config.get("port", DEFAULT_PORT))
+            user_ssh_config = parse_config(
+                host=config["host"], port=config.get("port", DEFAULT_PORT)
+            )
         except FileNotFoundError:
             user_ssh_config = {}
 

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -42,7 +42,8 @@ def parse_config(*, host, user=(), port=(), local_user=None, config_files=None):
 
     if config_files:
         if isinstance(config_files, (str, PurePath)):
-            paths: Sequence[FilePath] = [config_files]
+            # paths: Sequence[FilePath] = [config_files] #lint issue
+            paths = [config_files]
         else:
             paths = config_files
 

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -52,11 +52,15 @@ class SSHFileSystem(FileSystem):
             "client_factory", InteractiveSSHClient
         )
         try:
+            assert config.get("host) is not None
             user_ssh_config = parse_config(
                 host=config["host"], port=config.get("port", DEFAULT_PORT)
             )
 
         except FileNotFoundError:
+            user_ssh_config = {}
+        except Exception:
+            # host could have been None
             user_ssh_config = {}
 
         login_info["host"] = user_ssh_config.get("Hostname", config["host"])

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -92,9 +92,7 @@ class SSHFileSystem(FileSystem):
             "client_factory", InteractiveSSHClient
         )
         try:
-            user_ssh_config = parse_config(
-                host=config["host"], port=config.get("port")
-            )
+            user_ssh_config = parse_config(host=config["host"], port=config.get("port"))
         except FileNotFoundError:
             user_ssh_config = {}
 

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -53,8 +53,7 @@ class SSHFileSystem(FileSystem):
         )
         try:
             user_ssh_config = parse_config(
-                host=config["host"], 
-                port=config.get("port", DEFAULT_PORT)
+                host=config["host"], port=config.get("port", DEFAULT_PORT)
             )
 
         except FileNotFoundError:

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -93,7 +93,7 @@ class SSHFileSystem(FileSystem):
         )
         try:
             user_ssh_config = parse_config(
-                host=config["host"], port=config.get("port"))
+                host=config["host"], port=config.get("port")
             )
         except FileNotFoundError:
             user_ssh_config = {}

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -1,7 +1,6 @@
 import getpass
 import os.path
 import threading
-from collections.abc import Sequence
 from contextlib import suppress
 from pathlib import Path, PurePath
 from typing import ClassVar, Union

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -92,7 +92,7 @@ class SSHFileSystem(FileSystem):
             "client_factory", InteractiveSSHClient
         )
         try:
-            user_ssh_config = parse_config(host=config["host"], port=config.get("port"))
+            user_ssh_config = parse_config(host=config["host"])
         except FileNotFoundError:
             user_ssh_config = {}
 


### PR DESCRIPTION
Issue fixed :

while doing dvc pull or push, there was error. mainly due to the updated library code for ssh. 
TypeError: SSHClientConfig.__init__() missing 2 required positional arguments: 'host' and 'port'

![image](https://github.com/user-attachments/assets/db8b6c6b-8957-4692-97bf-30f1e17dc073)
The library function that causes exception is this.