### PR TITLE
implement password_auth_requested

### DIFF
--- a/dvc_ssh/client.py
+++ b/dvc_ssh/client.py
@@ -124,3 +124,16 @@ class InteractiveSSHClient(SSHClient):
             p = await _getpass(f"{prompt_prefix}{prompt}")
             response.append(p.rstrip())
         return response
+
+    async def password_auth_requested(self) -> str:
+        assert self._conn is not None
+        options = self._conn._options
+        prompt = "Password: "
+        addr = "@".join(filter(None, (options.username, options.host)))
+        if addr:
+            prompt = f"{addr}'s password: "
+
+        # NOTE: we write an extra line otherwise the prompt will be written on
+        # the same line as any active tqdm progress bars
+        sys.stderr.write(os.linesep)
+        return await _getpass(prompt)


### PR DESCRIPTION
Note that we already supported `KbdInteractiveAuthentication`, but did not support password-based authentication. 

The OpenSSH command defaults to `public-key,keyboard-interactive,password`, but this can be negotiated between servers from what I understand.

