### PR TITLE
fix #10909 unnecessary ssh password/passphrase prompts

### DIFF
--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -65,8 +65,19 @@ class SSHFileSystem(FileSystem):
         if port := config.get("port"):
             login_info["port"] = port
 
+        # in case preferred_auth is empty, fallback is publickey
+        login_info["preferred_auth"] = []
+
         for option in ("password", "passphrase"):
             login_info[option] = config.get(option)
+
+            if login_info[option] or config.get(f"ask_{option}"):
+                login_info["preferred_auth"].append(
+                    {
+                        "password": "password",
+                        "passphrase": "publickey",
+                    }[option]
+                )
 
             if config.get(f"ask_{option}") and login_info[option] is None:
                 login_info[option] = ask_password(

--- a/dvc_ssh/__init__.py
+++ b/dvc_ssh/__init__.py
@@ -65,19 +65,22 @@ class SSHFileSystem(FileSystem):
         if port := config.get("port"):
             login_info["port"] = port
 
-        # in case preferred_auth is empty, fallback is publickey
+        # we can constrain which authentication methods are used, to avoid trying ones
+        # the user doesn't have configured, which can lead to input prompts and timeouts
+        # asyncssh: empty list is falsy, so methods are not constrained and all tried
         login_info["preferred_auth"] = []
 
-        for option in ("password", "passphrase"):
+        # non exhaustive, maps which dvc config option uses which ssh auth method
+        _option_to_auth_methods = {
+            "password": "password",
+            "passphrase": "publickey",
+        }
+
+        for option, auth_method in _option_to_auth_methods.items():
             login_info[option] = config.get(option)
 
             if login_info[option] or config.get(f"ask_{option}"):
-                login_info["preferred_auth"].append(
-                    {
-                        "password": "password",
-                        "passphrase": "publickey",
-                    }[option]
-                )
+                login_info["preferred_auth"].append(auth_method)
 
             if config.get(f"ask_{option}") and login_info[option] is None:
                 login_info[option] = ask_password(

--- a/dvc_ssh/tests/docker-compose.yml
+++ b/dvc_ssh/tests/docker-compose.yml
@@ -5,7 +5,9 @@ services:
     image: ghcr.io/linuxserver/openssh-server
     environment:
       - USER_NAME=user
+      - USER_PASSWORD=password
       - PUBLIC_KEY_FILE=/tmp/key
+      - PASSWORD_ACCESS=true
     ports:
       - 2222
     volumes:

--- a/dvc_ssh/tests/test_conn.py
+++ b/dvc_ssh/tests/test_conn.py
@@ -2,27 +2,8 @@ from dvc_ssh import SSHFileSystem
 
 from .cloud import TEST_SSH_KEY_PATH
 
-# TODO: InteractiveSSHClient.public_key_auth_requested
 
-# "ssh": {
-#     "type": supported_cache_type,
-#     "port": Coerce(int),
-#     "user": str,
-#     "password": str,
-#     "ask_password": Bool,
-#     "passphrase": str,
-#     "ask_passphrase": Bool,
-#     "keyfile": str,
-#     "timeout": Coerce(int),
-#     "gss_auth": Bool,
-#     "allow_agent": Bool,
-#     "max_sessions": Coerce(int),
-#     Optional("verify", default=False): Bool,
-#     **REMOTE_COMMON,
-# },
-
-
-def test_denied_user(ssh_server, mocker):
+def test_keyfile_set(ssh_server, mocker):
     f = SSHFileSystem(
         host=ssh_server["host"],
         port=ssh_server["port"],

--- a/dvc_ssh/tests/test_conn.py
+++ b/dvc_ssh/tests/test_conn.py
@@ -1,0 +1,60 @@
+from dvc_ssh import SSHFileSystem
+
+from .cloud import TEST_SSH_KEY_PATH
+
+# TODO: InteractiveSSHClient.public_key_auth_requested
+
+# "ssh": {
+#     "type": supported_cache_type,
+#     "port": Coerce(int),
+#     "user": str,
+#     "password": str,
+#     "ask_password": Bool,
+#     "passphrase": str,
+#     "ask_passphrase": Bool,
+#     "keyfile": str,
+#     "timeout": Coerce(int),
+#     "gss_auth": Bool,
+#     "allow_agent": Bool,
+#     "max_sessions": Coerce(int),
+#     Optional("verify", default=False): Bool,
+#     **REMOTE_COMMON,
+# },
+
+
+def test_denied_user(ssh_server, mocker):
+    f = SSHFileSystem(
+        host=ssh_server["host"],
+        port=ssh_server["port"],
+        user="user",
+        keyfile=TEST_SSH_KEY_PATH,
+    )
+
+    assert f.fs
+
+
+def test_password_set(ssh_server, mocker):
+    f = SSHFileSystem(
+        host=ssh_server["host"],
+        port=ssh_server["port"],
+        user="user",
+        password="password",
+    )
+
+    assert f.fs
+
+
+def test_password_prompt(ssh_server, mocker):
+    f = SSHFileSystem(
+        host=ssh_server["host"],
+        port=ssh_server["port"],
+        user="user",
+        ask_password=True,
+    )
+
+    mock_getpass = mocker.patch(
+        "dvc_ssh.ask_password",
+    )
+    mock_getpass.return_value = "password"
+
+    assert f.fs

--- a/dvc_ssh/tests/test_conn.py
+++ b/dvc_ssh/tests/test_conn.py
@@ -15,9 +15,13 @@ def test_keyfile_set(ssh_server, mocker):
 
 
 def test_password_set(ssh_server, mocker):
+    # make sure that we don't open a password prompt if password is set
+    # this would let the test fail with a timeout
     f = SSHFileSystem(
         host=ssh_server["host"],
         port=ssh_server["port"],
+        # see config in tests/docker-compose.yml, can't use environment variable here
+        # because it is not passed to the test process
         user="user",
         password="password",
     )


### PR DESCRIPTION
Hey, this PR addresses this issue in the main `dvc` repository https://github.com/treeverse/dvc/issues/10909

The main issue was, that no matter what ssh configuration you set, the passphrase for the key is always prompted, even if you use `ask_password` and password based auth. 

This is due to the `InteractiveSSHClient` still trying to use the `publickey` auth if we don't set the `preferred_auth`, i.e. we will always call `public_key_auth_requested`. 

I've tried to replicate this behavior by expanding the docker based ssh tests, please let me know if you need some additional details/tests/etc